### PR TITLE
Improve performance when opening a DB

### DIFF
--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -142,6 +142,8 @@ describe("lib/db", () => {
 				emptyLines:
 					'\n{"k":"key1","v":1}\n\n\n{"k":"key2","v":"2"}\n\n',
 				broken: `{"k":"key1","v":1}\n{"k":,"v":1}\n`,
+				broken2: `{"k":"key1","v":1}\n{"k":"key2","v":}\n`,
+				broken3: `{"k":"key1"\n`,
 				reviver: `
 {"k":"key1","v":1}
 {"k":"key2","v":"2"}
@@ -215,8 +217,35 @@ describe("lib/db", () => {
 			}
 		});
 
+		it("throws when the file contains invalid JSON (part 2)", async () => {
+			const db = new JsonlDB("broken2");
+			try {
+				await db.open();
+				throw new Error("it did not throw");
+			} catch (e) {
+				expect(e.message).toMatch(/invalid data/i);
+				expect(e.message).toMatch("line 2");
+			}
+		});
+
+		it("throws when the file contains invalid JSON (part 3)", async () => {
+			const db = new JsonlDB("broken3");
+			try {
+				await db.open();
+				throw new Error("it did not throw");
+			} catch (e) {
+				expect(e.message).toMatch(/invalid data/i);
+				expect(e.message).toMatch("line 1");
+			}
+		});
+
 		it("does not throw when the file contains invalid JSON and `ignoreReadErrors` is true", async () => {
 			const db = new JsonlDB("broken", { ignoreReadErrors: true });
+			await expect(db.open()).toResolve();
+		});
+
+		it("does not throw when the file contains invalid JSON and `ignoreReadErrors` is true (part 2)", async () => {
+			const db = new JsonlDB("broken2", { ignoreReadErrors: true });
 			await expect(db.open()).toResolve();
 		});
 

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -138,15 +138,15 @@ describe("lib/db", () => {
 			mockFs({
 				yes:
 					// Final newline omitted on purpose
-					'{"k": "key1", "v": 1}\n{"k": "key2", "v": "2"}\n{"k": "key1"}',
+					'{"k":"key1","v":1}\n{"k":"key2","v":"2"}\n{"k":"key1"}',
 				emptyLines:
-					'\n{"k": "key1", "v": 1}\n\n\n{"k": "key2", "v": "2"}\n\n',
-				broken: `{"k": "key1", "v": 1}\n{"k":,"v":1}\n`,
+					'\n{"k":"key1","v":1}\n\n\n{"k":"key2","v":"2"}\n\n',
+				broken: `{"k":"key1","v":1}\n{"k":,"v":1}\n`,
 				reviver: `
-{"k": "key1", "v": 1}
-{"k": "key2", "v": "2"}
-{"k": "key1"}
-{"k": "key1", "v": true}`,
+{"k":"key1","v":1}
+{"k":"key2","v":"2"}
+{"k":"key1"}
+{"k":"key1","v":true}`,
 			});
 		});
 		afterEach(mockFs.restore);
@@ -224,8 +224,7 @@ describe("lib/db", () => {
 			const reviver = jest.fn().mockReturnValue("eeee");
 			const db = new JsonlDB("reviver", { reviver });
 			await db.open();
-			expect(reviver).toBeCalledTimes(3);
-			expect(reviver).toBeCalledWith("key1", 1);
+			expect(reviver).toBeCalledTimes(2);
 			expect(reviver).toBeCalledWith("key2", "2");
 			expect(reviver).toBeCalledWith("key1", true);
 
@@ -241,7 +240,7 @@ describe("lib/db", () => {
 		beforeEach(async () => {
 			mockFs({
 				[testFilename]:
-					'{"k": "key1", "v": 1}\n{"k": "key2", "v": "2"}\n{"k": "key1"}\n',
+					'{"k":"key1","v":1}\n{"k":"key2","v":"2"}\n{"k":"key1"}\n',
 			});
 			db = new JsonlDB(testFilename);
 			await db.open();
@@ -722,13 +721,13 @@ describe("lib/db", () => {
 		beforeEach(async () => {
 			mockFs({
 				[testFilename]: `
-{"k": "key1", "v": 1}
-{"k": "key2", "v": "2"}
-{"k": "key1"}
-{"k": "key2"}
-{"k": "key2", "v": "2"}
-{"k": "key3", "v": 3}
-{"k": "key3"}
+{"k":"key1","v":1}
+{"k":"key2","v":"2"}
+{"k":"key1"}
+{"k":"key2"}
+{"k":"key2","v":"2"}
+{"k":"key3","v":3}
+{"k":"key3"}
 `,
 			});
 			db = new JsonlDB(testFilename);
@@ -804,7 +803,7 @@ describe("lib/db", () => {
 		let db: JsonlDB;
 		beforeEach(async () => {
 			mockFs({
-				[testFilename]: `{"k": "key1", "v": 1}`,
+				[testFilename]: `{"k":"key1","v":1}`,
 				openClose: uncompressed,
 			});
 		});

--- a/test/perf.ts
+++ b/test/perf.ts
@@ -1,0 +1,44 @@
+import { JsonlDB } from "../src";
+
+const testDB: JsonlDB<any> = new JsonlDB("test.jsonl", {
+	autoCompress: { onClose: false },
+	throttleFS: {
+		intervalMs: 10000,
+	},
+});
+
+(async () => {
+	// await testDB.open();
+	// // add a shitton of values
+	// console.time("create values");
+	// const MAX_NODES = 100;
+	// for (let pass = 1; pass <= 10; pass++) {
+	// 	for (let nodeId = 1; nodeId <= MAX_NODES; nodeId++) {
+	// 		for (let ccId = 1; ccId <= 100; ccId++) {
+	// 			for (let endpoint = 0; endpoint <= 10; endpoint++) {
+	// 				for (const property of ["a", "b", "c", "d", "e"]) {
+	// 					const key = `${nodeId}-${ccId}-${endpoint}-${property}`;
+	// 					if (Math.random() < 0.15) {
+	// 						testDB.delete(key);
+	// 					} else {
+	// 						testDB.set(key, Math.random() * 100);
+	// 					}
+	// 				}
+	// 			}
+	// 		}
+	// 	}
+	// }
+	// await testDB.close();
+	// console.timeEnd("create values");
+
+	console.time("open values");
+	await testDB.open();
+	console.log(testDB.size);
+	console.timeEnd("open values");
+
+	await testDB.close();
+
+	// await fs.remove("test.jsonl");
+})().catch(() => {
+	/* ignore */
+});


### PR DESCRIPTION
With this PR, we no longer parse JSON lines that get overwritten by a later one while opening.

Using this approach, a test with a 200 MB `.jsonl` DB with ~470k entries could be opened in ~4.2 seconds instead of ~7.7 seconds.
This comes at a cost of temporarily higher memory consumption while opening the DB, so ideally this behavior should be toggled with an option (#123)