### PR TITLE
build: migrate to ES Modules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,7 @@ module.exports = {
 		"plugin:@typescript-eslint/recommended", // Uses the recommended rules from the @typescript-eslint/eslint-plugin
 		"plugin:prettier/recommended", // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
 	],
-	plugins: [],
+	plugins: ["unicorn"],
 	reportUnusedDisableDirectives: true,
 	rules: {
 		// Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
@@ -81,6 +81,7 @@ module.exports = {
 			{ allowArgumentsExplicitlyTypedAsAny: true },
 		],
 		"@typescript-eslint/no-this-alias": "off",
+		"unicorn/prefer-module": "error",
 	},
 	overrides: [
 		{
@@ -97,6 +98,7 @@ module.exports = {
 				"@typescript-eslint/no-floating-promises": "off",
 				"@typescript-eslint/require-await": "off",
 				"@typescript-eslint/unbound-method": "warn",
+				"unicorn/prefer-module": "off",
 			},
 		},
 		{

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,8 @@
 			"source.organizeImports": true
 		}
 	},
-	"editor.rulers": [72, 80, 120]
+	"editor.rulers": [72, 80, 120],
+	"javascript.preferences.importModuleSpecifierEnding": "js",
+	"typescript.preferences.importModuleSpecifierEnding": "js",
+	"typescript.preferences.importModuleSpecifier": "project-relative"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -131,6 +131,25 @@
         }
       }
     },
+    "@babel/eslint-parser": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.14.5.tgz",
+      "integrity": "sha512-20BlOHuGf3UXS7z1QPyllM9Gz8SEgcp/UcKeUmdHIFZO6HF1n+3KaLpeyfwWvjY/Os/ynPX3k8qXE/nZ5dw/0g==",
+      "dev": true,
+      "requires": {
+        "eslint-scope": "^5.1.1",
+        "eslint-visitor-keys": "^2.1.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "@babel/generator": {
       "version": "7.14.3",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.3.tgz",
@@ -4094,6 +4113,12 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
+    "builtin-modules": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
+      "integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==",
+      "dev": true
+    },
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
@@ -4322,6 +4347,15 @@
             "is-descriptor": "^0.1.0"
           }
         }
+      }
+    },
+    "clean-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
+      "integrity": "sha1-jffHquUf02h06PjQW5GAvBGj/tc=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "cli-cursor": {
@@ -5241,6 +5275,47 @@
         "prettier-linter-helpers": "^1.0.0"
       }
     },
+    "eslint-plugin-unicorn": {
+      "version": "33.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-33.0.1.tgz",
+      "integrity": "sha512-VxX/L/9DUEyB3D0v00185LrgsB5/fBwkgA4IC7ehHRu5hFSgA6VecmdpFybhsr4GQ/Y1iyXMHf6q+JKvcR2MwA==",
+      "dev": true,
+      "requires": {
+        "ci-info": "^3.1.1",
+        "clean-regexp": "^1.0.0",
+        "eslint-template-visitor": "^2.3.2",
+        "eslint-utils": "^3.0.0",
+        "import-modules": "^2.1.0",
+        "is-builtin-module": "^3.1.0",
+        "lodash": "^4.17.21",
+        "pluralize": "^8.0.0",
+        "read-pkg-up": "^7.0.1",
+        "regexp-tree": "^0.1.23",
+        "reserved-words": "^0.1.2",
+        "safe-regex": "^2.1.1",
+        "semver": "^7.3.5"
+      },
+      "dependencies": {
+        "eslint-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+          "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        },
+        "safe-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+          "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+          "dev": true,
+          "requires": {
+            "regexp-tree": "~0.1.1"
+          }
+        }
+      }
+    },
     "eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -5249,6 +5324,19 @@
       "requires": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-template-visitor": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-template-visitor/-/eslint-template-visitor-2.3.2.tgz",
+      "integrity": "sha512-3ydhqFpuV7x1M9EK52BPNj6V0Kwu0KKkcIAfpUhwHbR8ocRln/oUHgfxQupY8O1h4Qv/POHDumb/BwwNfxbtnA==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.12.16",
+        "@babel/eslint-parser": "^7.12.16",
+        "eslint-visitor-keys": "^2.0.0",
+        "esquery": "^1.3.1",
+        "multimap": "^1.1.0"
       }
     },
     "eslint-utils": {
@@ -6365,6 +6453,12 @@
         "resolve-cwd": "^3.0.0"
       }
     },
+    "import-modules": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-modules/-/import-modules-2.1.0.tgz",
+      "integrity": "sha512-8HEWcnkbGpovH9yInoisxaSoIg9Brbul+Ju3Kqe2UsYDUBJD/iQjSgEj0zPcTDPKfPp2fs5xlv1i+JSye/m1/A==",
+      "dev": true
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -6513,6 +6607,15 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
+    },
+    "is-builtin-module": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.1.0.tgz",
+      "integrity": "sha512-OV7JjAgOTfAFJmHZLvpSTb4qi0nIILDV1gWPYDnDJUTNFM5aGlRAhk4QcT8i7TuAleeEV5Fdkqn3t4mS+Q11fg==",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "^3.0.0"
+      }
     },
     "is-ci": {
       "version": "3.0.0",
@@ -10358,6 +10461,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "multimap": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/multimap/-/multimap-1.1.0.tgz",
+      "integrity": "sha512-0ZIR9PasPxGXmRsEF8jsDzndzHDj7tIav+JUmvIFB/WHswliFnquxECT/De7GR4yg99ky/NlRKJT82G1y271bw==",
+      "dev": true
+    },
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
@@ -10693,6 +10802,12 @@
         "find-up": "^4.0.0"
       }
     },
+    "pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true
+    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -10987,6 +11102,12 @@
         "safe-regex": "^1.1.0"
       }
     },
+    "regexp-tree": {
+      "version": "0.1.23",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.23.tgz",
+      "integrity": "sha512-+7HWfb4Bvu8Rs2eQTUIpX9I/PlQkYOuTNbRpKLJlQpSgwSkzFYh+pUj0gtvglnOZLKB6YgnIgRuJ2/IlpL48qw==",
+      "dev": true
+    },
     "regexpp": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
@@ -11099,6 +11220,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
+    },
+    "reserved-words": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.2.tgz",
+      "integrity": "sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE=",
       "dev": true
     },
     "resolve": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,31 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@alcalzone/esm2cjs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@alcalzone/esm2cjs/-/esm2cjs-1.1.0.tgz",
+      "integrity": "sha512-r9nmhZpZ4SnI721Cpw92m1VEOeTHxLjr14b7th8iwKYiiM3u55kfL3RioeJKpwyXjOhR9VCTSN/084rCTbE0qA==",
+      "dev": true,
+      "requires": {
+        "esbuild": "^0.12.9",
+        "fs-extra": "^10.0.0",
+        "tiny-glob": "^0.2.9",
+        "yargs": "^16.2.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+          "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        }
+      }
+    },
     "@alcalzone/release-script": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@alcalzone/release-script/-/release-script-1.10.0.tgz",
@@ -3063,6 +3088,12 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
+    "@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
     "@types/babel__core": {
       "version": "7.1.14",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.14.tgz",
@@ -4874,6 +4905,22 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "esbuild": {
+      "version": "0.12.9",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.9.tgz",
+      "integrity": "sha512-MWRhAbMOJ9RJygCrt778rz/qNYgA4ZVj6aXnNPxFjs7PmIpb0fuB9Gmg5uWrr6n++XKwwm/RmSz6RR5JL2Ocsw==",
+      "dev": true
+    },
+    "esbuild-register": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-2.6.0.tgz",
+      "integrity": "sha512-2u4AtnCXP5nivtIxZryiZOUcEQkOzFS7UhAqibUEmaTAThJ48gDLYTBF/Fsz+5r0hbV1jrFE6PQvPDUrKZNt/Q==",
+      "dev": true,
+      "requires": {
+        "esbuild": "^0.12.8",
+        "jsonc-parser": "^3.0.0"
+      }
+    },
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -6052,6 +6099,12 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
+    "globalyzer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
+      "dev": true
+    },
     "globby": {
       "version": "11.0.3",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
@@ -6073,6 +6126,12 @@
           "dev": true
         }
       }
+    },
+    "globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
     },
     "graceful-fs": {
       "version": "4.2.3",
@@ -9931,6 +9990,12 @@
         "minimist": "^1.2.5"
       }
     },
+    "jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
+    },
     "jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -11747,6 +11812,16 @@
             "util-deprecate": "^1.0.1"
           }
         }
+      }
+    },
+    "tiny-glob": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+      "dev": true,
+      "requires": {
+        "globalyzer": "0.1.0",
+        "globrex": "^0.1.2"
       }
     },
     "tmp": {

--- a/package.json
+++ b/package.json
@@ -2,8 +2,16 @@
   "name": "@alcalzone/jsonl-db",
   "version": "1.2.5",
   "description": "Simple JSONL-based key-value store",
-  "main": "./build/index.js",
-  "types": "./build/index.d.ts",
+  "main": "build/cjs/index.js",
+  "module": "build/esm/index.js",
+  "exports": {
+    ".": {
+      "import": "./build/esm/index.js",
+      "require": "./build/cjs/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "types": "build/esm/index.d.ts",
   "files": [
     "build/**/*.{js,d.ts,map}"
   ],
@@ -33,6 +41,7 @@
   },
   "homepage": "https://github.com/AlCalzone/jsonl-db#readme",
   "devDependencies": {
+    "@alcalzone/esm2cjs": "^1.1.0",
     "@alcalzone/release-script": "^1.10.0",
     "@babel/cli": "^7.14.3",
     "@babel/core": "^7.14.3",
@@ -40,6 +49,7 @@
     "@babel/preset-typescript": "^7.13.0",
     "@commitlint/cli": "^12.1.4",
     "@commitlint/config-conventional": "^12.1.4",
+    "@tsconfig/node12": "^1.0.9",
     "@types/fs-extra": "^9.0.11",
     "@types/jest": "^26.0.23",
     "@types/mock-fs": "^4.13.0",
@@ -49,6 +59,7 @@
     "@typescript-eslint/parser": "^4.26.0",
     "commitizen": "^4.2.4",
     "coveralls": "^3.1.0",
+    "esbuild-register": "^2.6.0",
     "eslint": "^7.27.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^3.4.0",
@@ -58,6 +69,7 @@
     "mock-fs": "^4.14.0",
     "prettier": "^2.3.0",
     "source-map-support": "^0.5.19",
+    "tiny-glob": "^0.2.9",
     "ts-node": "^9.1.1",
     "typescript": "^4.3.2"
   },
@@ -68,6 +80,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
+    "postbuild": "esm2cjs --in=build/esm --out=build/cjs -t node12",
     "watch": "npm run build -- --watch",
     "test:reset": "jest --clear-cache",
     "test:ts": "jest",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "eslint": "^7.27.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^3.4.0",
+    "eslint-plugin-unicorn": "^33.0.1",
     "husky": "^6.0.0",
     "jest": "^27.0.3",
     "jest-extended": "^0.11.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { FsWriteOptions, JsonlDB, JsonlDBOptions } from "./lib/db";
+export { FsWriteOptions, JsonlDB, JsonlDBOptions } from "./lib/db.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { FsWriteOptions, JsonlDB, JsonlDBOptions } from "./lib/db.js";
+export { FsWriteOptions, JsonlDB, JsonlDBOptions } from "./lib/db";

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -1,7 +1,7 @@
 import { wait } from "alcalzone-shared/async";
 import * as fs from "fs-extra";
 import mockFs from "mock-fs";
-import { JsonlDB } from "./db";
+import { JsonlDB } from "./db.js";
 
 let mockAppendFileThrottle = 0;
 let mockMoveFileThrottle = 0;

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -1,7 +1,7 @@
 import { wait } from "alcalzone-shared/async";
 import * as fs from "fs-extra";
 import mockFs from "mock-fs";
-import { JsonlDB } from "./db.js";
+import { JsonlDB } from "./db";
 
 let mockAppendFileThrottle = 0;
 let mockMoveFileThrottle = 0;

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -1,0 +1,44 @@
+import { JsonlDB } from "@alcalzone/jsonl-db";
+
+const testDB = new JsonlDB("test.jsonl", {
+	autoCompress: { onClose: false },
+	throttleFS: {
+		intervalMs: 10000,
+	},
+});
+
+(async () => {
+	await testDB.open();
+	// add a shitton of values
+	console.time("create values");
+	const MAX_NODES = 10;
+	for (let pass = 1; pass <= 10; pass++) {
+		for (let nodeId = 1; nodeId <= MAX_NODES; nodeId++) {
+			for (let ccId = 1; ccId <= 10; ccId++) {
+				for (let endpoint = 0; endpoint <= 10; endpoint++) {
+					for (const property of ["a", "b", "c", "d", "e"]) {
+						const key = `${nodeId}-${ccId}-${endpoint}-${property}`;
+						if (Math.random() < 0.15) {
+							testDB.delete(key);
+						} else {
+							testDB.set(key, Math.random() * 100);
+						}
+					}
+				}
+			}
+		}
+	}
+	await testDB.close();
+	console.timeEnd("create values");
+
+	console.time("open values");
+	await testDB.open();
+	console.log(testDB.size);
+	console.timeEnd("open values");
+
+	await testDB.close();
+
+	// await fs.remove("test.jsonl");
+})().catch(() => {
+	/* ignore */
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,18 @@
 {
+	"extends": "@tsconfig/node12/tsconfig.json",
 	"compilerOptions": {
 		"noEmit": true,
-		"declaration": false,
-		"module": "commonjs",
-		"moduleResolution": "node",
 		"noEmitOnError": true,
-		"strict": true,
-		"outDir": "build/",
-		"removeComments": false,
-		"importsNotUsedAsValues": "error",
+		"declaration": false,
+		"outDir": "build/esm",
+		// For ES modules
+		"module": "ES2020",
+		"moduleResolution": "node",
 		"sourceMap": true,
 		"inlineSourceMap": false,
 		"stripInternal": true,
-		"target": "es2017",
+		"removeComments": false,
+		"importsNotUsedAsValues": "error",
 		"watch": false, // true breaks circleci
 		"pretty": true,
 		"types": [
@@ -21,14 +21,10 @@
 			"jest-extended"
 		],
 		"allowSyntheticDefaultImports": true,
-		/* Advanced Options */
-		"forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
 	},
 	"include": [
 		"src/**/*.ts",
-		"maintenance/**/*.ts",
-		"test/**/*.ts",
-		"gulpfile.ts"
+		"test/**/*.ts"
 	],
 	"exclude": [
 		"build/**",


### PR DESCRIPTION
Blocked by:
- [ ] Proper TypeScript support
- [ ] an ESM version of shared-utils