### PR TITLE
perf: serialize into a string, then write to disk once

### DIFF
--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -668,7 +668,9 @@ describe("lib/db", () => {
 			// simulate a slow FS
 			mockAppendFileThrottle = 50;
 			let dumpPromise: Promise<void>;
-			for (let i = 1; i < 20; i++) {
+			// 10 entries are written before the dump
+			// Afterwards: write 11, 20ms pause, delete 11, 20ms pause, write 13, dump done
+			for (let i = 1; i <= 13; i++) {
 				if (i % 4 === 0) {
 					db.delete(`${i - 1}`);
 				} else {
@@ -698,7 +700,7 @@ describe("lib/db", () => {
 			// dump without waiting
 			db.dump();
 			// wait a bit, so the files are being opened
-			await wait(100);
+			await wait(20);
 			// and write something that will be put into the dump backlog
 			db.set("21", 21);
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -883,8 +883,8 @@ export class JsonlDB<V extends unknown = unknown> {
 		if (this._dumpBacklog) {
 			// Disable writing into the dump backlog stream
 			this._dumpBacklog.end();
-			await this._dumpPromise;
 		}
+		if (this._dumpPromise) await this._dumpPromise;
 
 		// Reset all variables
 		this._writePromise = undefined;


### PR DESCRIPTION
Another performance improvement. It turns out that the 2.4.0 changes were actually slower for small to medium objects compared to the simple values we tested.

```
2.3.0
10x, 0 keys, 100000 changes
  4160.50 ms / attempt
  2403.56 changes/s

2.4.0
10x, 0 keys, 100000 changes
  5698.30 ms / attempt
  1754.91 changes/s

2.4.0, maxBufferedCommands = 1000
10x, 0 keys, 100000 changes
  5669.80 ms / attempt
  1763.73 changes/s

2.4.0, sizeFactor = 5
10x, 0 keys, 100000 changes
  5686.40 ms / attempt
  1758.58 changes/s
```

This change bumps it to:
```
2.4.0, write once
10x, 0 keys, 100000 changes
  485.70 ms / attempt
  20588.84 changes/s
```