### PR TITLE
fix: avoid throwing in tryRecoverDBFiles, decouple and cleanup persistence

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -394,15 +394,19 @@ export class JsonlDB<V extends unknown = unknown> {
 
 		if (bakFileIsOK) {
 			// Overwrite the broken db file with it and delete the dump file
-			await fs.move(this.backupFilename, this.filename, {
-				overwrite: true,
-			});
 			try {
-				await fs.remove(this.dumpFilename);
+				await fs.move(this.backupFilename, this.filename, {
+					overwrite: true,
+				});
+				try {
+					await fs.remove(this.dumpFilename);
+				} catch {
+					// ignore
+				}
+				return;
 			} catch {
-				// ignore
+				// Moving failed, try the next possibility
 			}
-			return;
 		}
 
 		// Try the dump file as a last attempt
@@ -414,16 +418,20 @@ export class JsonlDB<V extends unknown = unknown> {
 			// ignore
 		}
 		if (dumpFileIsOK) {
-			// Overwrite the broken db file with the dump file and delete the backup file
-			await fs.move(this.dumpFilename, this.filename, {
-				overwrite: true,
-			});
 			try {
-				await fs.remove(this.backupFilename);
+				// Overwrite the broken db file with the dump file and delete the backup file
+				await fs.move(this.dumpFilename, this.filename, {
+					overwrite: true,
+				});
+				try {
+					await fs.remove(this.backupFilename);
+				} catch {
+					// ignore
+				}
+				return;
 			} catch {
-				// ignore
+				// Moving failed
 			}
-			return;
 		}
 	}
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -628,7 +628,12 @@ export class JsonlDB<V extends unknown = unknown> {
 	 * Saves a compressed copy of the DB into the given path.
 	 * @param targetFilename Where the compressed copy should be written. Default: `<filename>.dump`
 	 */
-	public dump(targetFilename: string = this.dumpFilename): Promise<void> {
+	public async dump(
+		targetFilename: string = this.dumpFilename,
+	): Promise<void> {
+		// Prevent dumping the DB when it is closed
+		if (!this._isOpen) return;
+
 		const done = createDeferredPromise();
 		this._persistenceTasks.push({
 			type: "dump",

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -240,18 +240,6 @@ export class JsonlDB<V extends unknown = unknown> {
 		return this._journal.splice(0, this._journal.length);
 	}
 
-	// private filterJournal(predicate: (e: LazyEntry<V>) => boolean): void {
-	// 	let i = 0;
-	// 	while (i < this._journal.length) {
-	// 		const entry = this._journal[i];
-	// 		if (predicate(entry)) {
-	// 			i++;
-	// 		} else {
-	// 			this._journal.splice(i, 1);
-	// 		}
-	// 	}
-	// }
-
 	private _openPromise: DeferredPromise<void> | undefined;
 	// /** Opens the database file or creates it if it doesn't exist */
 	public async open(): Promise<void> {
@@ -494,16 +482,6 @@ export class JsonlDB<V extends unknown = unknown> {
 		const ret = this._db.delete(key);
 		if (ret) {
 			// Something was deleted
-			// // Deduplicate while inserting, removing all previous pending writes for this key
-			// this.filterJournal((e) => {
-			// 	if (e.op === Operation.Write && e.key === key) {
-			// 		return false;
-			// 	} else if (e.op === Operation.Delete && e.key === key) {
-			// 		return false;
-			// 	} else {
-			// 		return true;
-			// 	}
-			// });
 			this._journal.push(this.makeLazyDelete(key));
 		}
 		return ret;
@@ -514,16 +492,6 @@ export class JsonlDB<V extends unknown = unknown> {
 			throw new Error("The database is not open!");
 		}
 		this._db.set(key, value);
-		// // Deduplicate while inserting, removing all previous pending writes for this key
-		// this.filterJournal((e) => {
-		// 	if (e.op === Operation.Write && e.key === key) {
-		// 		return false;
-		// 	} else if (e.op === Operation.Delete && e.key === key) {
-		// 		return false;
-		// 	} else {
-		// 		return true;
-		// 	}
-		// });
 		this._journal.push(this.makeLazyWrite(key, value));
 		return this;
 	}

--- a/test/perf.ts
+++ b/test/perf.ts
@@ -1,8 +1,9 @@
+/* eslint-disable @typescript-eslint/no-inferrable-types */
 import { padStart } from "alcalzone-shared/strings";
 import fs from "fs-extra";
 import { JsonlDB } from "../src";
 
-process.on("unhandledRejection", (r) => {
+process.on("unhandledRejection", (_r) => {
 	debugger;
 });
 
@@ -64,8 +65,12 @@ async function testMedium() {
 	process.stdout.write("\n\n");
 
 	console.log(`${NUM_PASSES}x, ${NUM_OBJECTS} objects`);
-	console.log(`  ${(total / NUM_PASSES).toFixed(2)} ms / attempt`);
-	console.log(`  ${((NUM_OBJECTS / total) * 1000).toFixed(2)} changes/s`);
+	console.log(`  ${(total / NUM_PASSES).toFixed(2)} ms / pass`);
+	console.log(
+		`  ${(((NUM_OBJECTS * NUM_PASSES) / total) * 1000).toFixed(
+			2,
+		)} changes/s`,
+	);
 	console.log();
 	console.log();
 }
@@ -117,12 +122,17 @@ async function testSmall() {
 	process.stdout.write("\n\n");
 
 	console.log(`${NUM_PASSES}x, ${NUM_KEYS} keys, ${NUM_CHANGES} changes`);
-	console.log(`  ${(total / NUM_PASSES).toFixed(2)} ms / attempt`);
-	console.log(`  ${((NUM_CHANGES / total) * 1000).toFixed(2)} changes/s`);
+	console.log(`  ${(total / NUM_PASSES).toFixed(2)} ms / pass`);
+	console.log(
+		`  ${(((NUM_CHANGES * NUM_PASSES) / total) * 1000).toFixed(
+			2,
+		)} changes/s`,
+	);
 	console.log();
 	console.log();
 }
 
+debugger;
 testSmall()
 	.then(testMedium)
 	.catch(console.error)


### PR DESCRIPTION
fixes: #277
(hopefully)

Also gives quite a performance boost when persisting primitives. (~800k -> 1.6M changes/s, including closing the DB after each set of 100k changes)