### PR TITLE
feat: retry acquiring lockfile, change timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,20 @@ The following options exist:
 
 To create a compressed copy of the database in `/path/to/file.dump`, use the `dump()` method. If any data is written to the db during the dump, it is appended to the dump but most likely compressed.
 
-### Changing where the lockfile is created
+### Lockfile-related options
 
-Normally, the lockfile to avoid concurrent access to the DB file is created right next to the DB file. You can change this, e.g. to put the lockfile into a `tmpfs`:
+A lockfile is used to avoid concurrent access to the DB file. Multiple options exist to control where this lockfile is created and how it is accessed:
 ```ts
-const db = new DB("/path/to/file", { lockfileDirectory: "/var/tmp" });
+const db = new DB("/path/to/file", { lockfile: { /* lockfile options */ } });
 ```
-If the directory does not exist, it will be created when opening the DB.
+
+| Option | Default | Description |
+|-----------------|---------|-------------|
+| `directory` | - | Change where the lockfile is created, e.g. to put the lockfile into a `tmpfs`. By default the lockfile is created in the same directory as the DB file. If the directory does not exist, it will be created when opening the DB. |
+| `staleMs` | `10000` | Duration after which the lock is considered stale. Minimum: `5000` |
+| `updateMs` | `staleMs/2` | The interval in which the lockfile's `mtime` will be updated. Range: `1000 ... staleMs/2` |
+| `retries` | `0` | How often to retry acquiring a lock before giving up. The retries progressively wait longer with an exponential backoff strategy. |
+
 
 ### Copying and compressing the database
 

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -132,6 +132,76 @@ describe("lib/db", () => {
 				).toThrowError("maxBufferedCommands");
 			});
 		});
+
+		describe("validates lockfile options", () => {
+			it("staleMs < 5000", () => {
+				expect(
+					() =>
+						new JsonlDB("foo", {
+							lockfile: {
+								staleMs: 2500,
+							},
+						}),
+				).toThrowError("staleMs");
+			});
+
+			it("updateMs < 1000", () => {
+				expect(
+					() =>
+						new JsonlDB("foo", {
+							lockfile: {
+								updateMs: 999,
+							},
+						}),
+				).toThrowError("updateMs");
+			});
+
+			it("updateMs > staleMs/2", () => {
+				expect(
+					() =>
+						new JsonlDB("foo", {
+							lockfile: {
+								staleMs: 5000,
+								updateMs: 10001,
+							},
+						}),
+				).toThrowError("updateMs");
+			});
+
+			it("retries < 0", () => {
+				expect(
+					() =>
+						new JsonlDB("foo", {
+							lockfile: {
+								retries: -1,
+							},
+						}),
+				).toThrowError("retries");
+			});
+
+			it("retries > 10", () => {
+				expect(
+					() =>
+						new JsonlDB("foo", {
+							lockfile: {
+								retries: 11,
+							},
+						}),
+				).toThrowError("retries");
+			});
+
+			it("lockfileDirectory and lockfile.directory both present", () => {
+				expect(
+					() =>
+						new JsonlDB("foo", {
+							lockfile: {
+								directory: "/lock/dir",
+							},
+							lockfileDirectory: "/lock/dir2",
+						}),
+				).toThrowError("lockfileDirectory");
+			});
+		});
 	});
 
 	describe("open()", () => {


### PR DESCRIPTION
This PR adds a set of options to control lockfile stale/update timeouts and retrying to acquire a lockfile.