### PR TITLE
fix: eliminate busy loop in `persistenceThread`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,7 @@
 	],
 	"[typescript]": {
 		"editor.codeActionsOnSave": {
-			"source.organizeImports": true
+			"source.organizeImports": "explicit"
 		}
 	},
 	"editor.rulers": [

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -1132,7 +1132,7 @@ describe("lib/db", () => {
 		});
 
 		it("..., but only above the minimum size", async () => {
-			await retry(5, async () => {
+			await retry(1, async () => {
 				db = new JsonlDB(testFilenameFull, {
 					autoCompress: {
 						sizeFactor: 4,
@@ -1776,7 +1776,7 @@ describe("lib/db", () => {
 `,
 				);
 			});
-		}, 120000);
+		});
 
 		it("should be parsed from the db file", async () => {
 			await retry(3, async () => {

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -1752,7 +1752,6 @@ describe("lib/db", () => {
 				await testFS.create({
 					[testFilename]: ``,
 				});
-				console.log(testFilenameFull);
 
 				db = new JsonlDB(testFilenameFull, {
 					enableTimestamps: true,

--- a/src/lib/signal.test.ts
+++ b/src/lib/signal.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { Signal } from "./signal";
+
+describe("signal", () => {
+	it("can be awaited and resolves immediately when set", async () => {
+		const signal = new Signal();
+		signal.set();
+		await signal;
+	});
+
+	it("can be awaited and resolves when set", async () => {
+		const signal = new Signal();
+		setTimeout(() => signal.set(), 100);
+		await signal;
+	});
+
+	it("does not resolve when awaited after being reset", async () => {
+		const signal = new Signal();
+		signal.set();
+		signal.reset();
+
+		const result = await Promise.race([
+			signal.then(() => "resolved"),
+			new Promise((resolve) => setTimeout(resolve, 100)).then(
+				() => "timeout",
+			),
+		]);
+
+		expect(result).toBe("timeout");
+	});
+
+	it("can be re-awaited multiple times in sequence", async () => {
+		const signal = new Signal();
+
+		setTimeout(() => signal.set(), 100);
+		await signal;
+		signal.reset();
+
+		setTimeout(() => signal.set(), 100);
+		await signal;
+		signal.reset();
+
+		setTimeout(() => signal.set(), 100);
+		await signal;
+		signal.reset();
+	});
+});

--- a/src/lib/signal.ts
+++ b/src/lib/signal.ts
@@ -1,0 +1,37 @@
+import {
+	createDeferredPromise,
+	type DeferredPromise,
+} from "alcalzone-shared/deferred-promise";
+
+/** Can be used to asynchronously signal a single listener */
+export class Signal {
+	private _listener: DeferredPromise<void> | undefined;
+
+	private _status: boolean = false;
+	public get isSet(): boolean {
+		return this._status;
+	}
+
+	public set(): void {
+		if (this._status) return;
+		this._status = true;
+		if (this._listener) {
+			this._listener.resolve(undefined);
+		}
+	}
+
+	public reset(): void {
+		this._status = false;
+		this._listener = undefined;
+	}
+
+	public then<T>(onfulfilled: () => T | PromiseLike<T>): Promise<T> {
+		if (this._status) {
+			return Promise.resolve(onfulfilled());
+		} else {
+			const p = createDeferredPromise();
+			this._listener = p;
+			return p.then(onfulfilled);
+		}
+	}
+}

--- a/test/cpu.ts
+++ b/test/cpu.ts
@@ -1,0 +1,25 @@
+import { JsonlDB } from "../src";
+
+async function main() {
+	const testDB: JsonlDB<any> = new JsonlDB("test.jsonl", {
+		autoCompress: {
+			sizeFactor: 2,
+			sizeFactorMinimumSize: 5000,
+		},
+		ignoreReadErrors: true,
+		throttleFS: {
+			intervalMs: 60000,
+			maxBufferedCommands: 100,
+		},
+	});
+
+	await testDB.open();
+	for (let i = 0; i < 100; i++) {
+		testDB.set(`benchmark.0.test${i}`, i);
+	}
+
+	await new Promise((resolve) => setTimeout(resolve, 20000));
+
+	await testDB.close();
+}
+void main();


### PR DESCRIPTION
This PR reworks the `persistenceThread` to be signal and timeout-based instead of repeatedly checking in a tight loop. This reduces the idle CPU usage to almost nothing.